### PR TITLE
fix: 修复e2e测试中状态枚举值大小写不匹配问题 (#121, #120)

### DIFF
--- a/tests/integration/e2e.test.ts
+++ b/tests/integration/e2e.test.ts
@@ -9,6 +9,8 @@ import { AirdropService } from '../../src/services/airdrop.service';
 import { TaskService } from '../../src/services/task.service';
 import { FreezeService } from '../../src/services/freeze.service';
 import { TransactionType } from '../../src/types/token';
+import { AirdropStatus } from '../../src/types/airdrop';
+import { TaskStatus } from '../../src/types/task';
 
 describe('端到端业务流程测试', () => {
   let accountService: AccountService;
@@ -230,12 +232,12 @@ describe('端到端业务流程测试', () => {
       });
 
       expect(airdrop.airdropId).toBeDefined();
-      expect(airdrop.status).toBe('PENDING');
+      expect(airdrop.status).toBe(AirdropStatus.PENDING);
 
       // 2. 激活空投
       await airdropService.startAirdrop(airdrop.airdropId);
-      const activeAirdrop = airdropService.getAirdrop(airdrop.airdropId);
-      expect(activeAirdrop?.status).toBe('ACTIVE');
+      const activeAirdropDetail = airdropService.getAirdropDetail(airdrop.airdropId);
+      expect(activeAirdropDetail?.airdrop.status).toBe(AirdropStatus.ACTIVE);
 
       // 3. 创建多个用户并领取
       const users = [];
@@ -317,12 +319,12 @@ describe('端到端业务流程测试', () => {
       });
 
       expect(task.taskId).toBeDefined();
-      expect(task.status).toBe('PENDING');
+      expect(task.status).toBe(TaskStatus.DRAFT);
 
       // 2. 激活任务
       await taskService.activateTask(task.taskId);
-      const activeTask = taskService.getTask(task.taskId);
-      expect(activeTask?.status).toBe('ACTIVE');
+      const activeTaskDetail = taskService.getTaskDetail(task.taskId);
+      expect(activeTaskDetail?.task.status).toBe(TaskStatus.ACTIVE);
 
       // 3. 多个用户完成任务
       for (let i = 0; i < maxCompletions; i++) {


### PR DESCRIPTION
## 🐛 问题描述

修复端到端测试中状态枚举值大小写不一致导致的测试失败。

## 📋 具体问题

### Issue #121 - 状态枚举值大小写不一致
- **测试代码**：使用硬编码大写字符串 `expect(status).toBe('PENDING')`
- **枚举定义**：使用小写字符串 `PENDING = 'pending'`
- **结果**：测试期望与实际返回值不匹配 ❌

### Issue #120 - e2e测试与实现不匹配
- 测试调用了不存在的方法：`getAirdrop()`, `getTask()`
- 实际服务提供的方法：`getAirdropDetail()`, `getTaskDetail()`

## ✅ 修复内容

### 1. 导入枚举类型
```typescript
import { AirdropStatus } from '../../src/types/airdrop';
import { TaskStatus } from '../../src/types/task';
```

### 2. 替换硬编码字符串为枚举常量
- ❌ `expect(airdrop.status).toBe('PENDING')`
- ✅ `expect(airdrop.status).toBe(AirdropStatus.PENDING)`

### 3. 修正任务初始状态期望
- ❌ `expect(task.status).toBe('PENDING')` （任务创建后初始状态是 DRAFT）
- ✅ `expect(task.status).toBe(TaskStatus.DRAFT)`

### 4. 修正方法调用
- ❌ `airdropService.getAirdrop(id)` 
- ✅ `airdropService.getAirdropDetail(id).airdrop`

- ❌ `taskService.getTask(id)`
- ✅ `taskService.getTaskDetail(id).task`

## 📊 影响范围

- `tests/integration/e2e.test.ts` (1 file, 8 insertions, 6 deletions)

## 🧪 测试结果

部分测试现在可以通过，其他失败需要进一步修复业务逻辑（不在本次修复范围内）：
- ✅ 状态枚举匹配问题已解决
- ✅ 方法调用问题已解决
- ⚠️ 冻结余额计算、交易历史等其他问题需要单独处理

## 📝 关联Issue

- Fixes #121
- Related #120