### PR TITLE
fix(tests): 添加 FreezeStatus 枚举导入并替换硬编码字符串 (#121)

### DIFF
--- a/tests/integration/e2e.test.ts
+++ b/tests/integration/e2e.test.ts
@@ -11,6 +11,7 @@ import { FreezeService } from '../../src/services/freeze.service';
 import { TransactionType } from '../../src/types/token';
 import { AirdropStatus } from '../../src/types/airdrop';
 import { TaskStatus } from '../../src/types/task';
+import { FreezeStatus } from '../../src/types/freeze';
 
 describe('端到端业务流程测试', () => {
   let accountService: AccountService;
@@ -143,7 +144,7 @@ describe('端到端业务流程测试', () => {
         remark: '交易保证金'
       });
 
-      expect(freeze.status).toBe('FROZEN');
+      expect(freeze.status).toBe(FreezeStatus.FROZEN);
       expect(freeze.amount).toBe(freezeAmount);
 
       // 3. 验证可用余额减少
@@ -153,7 +154,7 @@ describe('端到端业务流程测试', () => {
 
       // 4. 查询冻结状态
       const freezeStatus = freezeService.getFreezeStatus(freeze.id);
-      expect(freezeStatus.status).toBe('FROZEN');
+      expect(freezeStatus.status).toBe(FreezeStatus.FROZEN);
       expect(freezeStatus.amount).toBe(freezeAmount);
       expect(freezeStatus.remainingTime).toBeGreaterThan(0);
 
@@ -164,7 +165,7 @@ describe('端到端业务流程测试', () => {
 
       // 6. 解冻
       const unfreezeResult = freezeService.unfreeze(freeze.id, '交易完成，释放保证金');
-      expect(unfreezeResult.status).toBe('UNFROZEN');
+      expect(unfreezeResult.status).toBe(FreezeStatus.UNFROZEN);
 
       // 7. 验证余额恢复
       const afterUnfreeze = accountService.getTokenBalance(user);
@@ -173,7 +174,7 @@ describe('端到端业务流程测试', () => {
 
       // 8. 验证冻结记录状态更新
       const finalFreezeStatus = freezeService.getFreezeStatus(freeze.id);
-      expect(finalFreezeStatus.status).toBe('UNFROZEN');
+      expect(finalFreezeStatus.status).toBe(FreezeStatus.UNFROZEN);
     });
 
     test('多次冻结和部分解冻场景', async () => {


### PR DESCRIPTION
## 🐛 问题描述

**Issue**: #121

测试代码中 FreezeStatus 仍使用硬编码字符串字面量，与枚举定义不匹配，可能导致测试失败。

### 当前状态
- ✅ AirdropStatus 已修复（PR #161）
- ✅ TaskStatus 已修复（PR #161）
- ❌ FreezeStatus 仍使用硬编码字符串

## ✅ 修复方案

添加 FreezeStatus 枚举导入，并替换所有硬编码字符串。

### 修改内容

1. **导入枚举类型**：
   ```typescript
   import { FreezeStatus } from '../../src/types/freeze';
   ```

2. **替换硬编码字符串**（4处）：
   - `'FROZEN'` → `FreezeStatus.FROZEN`
   - `'UNFROZEN'` → `FreezeStatus.UNFROZEN`

### 影响范围
- `tests/integration/e2e.test.ts` (5行修改)

## 📋 测试验证

**修改前**：
```typescript
expect(freeze.status).toBe('FROZEN');  // ❌ 硬编码字符串
```

**修改后**：
```typescript
expect(freeze.status).toBe(FreezeStatus.FROZEN);  // ✅ 枚举常量
```

## 🎯 验收标准

- [x] 导入语句无语法错误
- [x] 所有 FreezeStatus 使用枚举常量
- [x] 测试可以正常执行
- [x] 不修改枚举定义（只修改测试代码）

## 📌 注意事项

- 这是对 Issue #121 的补充修复
- 补充了 PR #161 中遗漏的 FreezeStatus 修复
- 优先级：P1（影响测试通过率）